### PR TITLE
Ajout de l'option pour exercer le droit d'accès

### DIFF
--- a/config/question-tree.yaml
+++ b/config/question-tree.yaml
@@ -32,6 +32,12 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:
@@ -86,6 +92,12 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:
@@ -119,6 +131,12 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:
@@ -202,6 +220,12 @@ choices:
         form:
           title: Contactez-nous (nous vous invitons à consulter la documentation au préalable)
           recipient: certification@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:
@@ -285,6 +309,12 @@ choices:
         form:
           title: Contactez-nous (nous vous invitons à consulter la documentation au préalable)
           recipient: certification@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:
@@ -339,6 +369,12 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:
@@ -397,6 +433,12 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:
@@ -455,6 +497,12 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
+    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
+      id: droit-acces
+      link:
+        form:
+          title: Contactez-nous
+          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
       link:

--- a/config/question-tree.yaml
+++ b/config/question-tree.yaml
@@ -35,7 +35,7 @@ choices:
       link:
         form:
           title: Contactez-nous
-          recipient: contact@data.gouv.fr
+          recipient: support@data.gouv.fr
     - label: "Question sur des données géographiques"
       id: geo
       link:

--- a/config/question-tree.yaml
+++ b/config/question-tree.yaml
@@ -77,12 +77,6 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
-    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
-      id: droit-acces
-      link:
-        form:
-          title: Contactez-nous
-          recipient: contact@data.gouv.fr
     - label: "Question sur des données géographiques"
       id: geo
       link:
@@ -118,12 +112,6 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
-    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
-      id: droit-acces
-      link:
-        form:
-          title: Contactez-nous
-          recipient: contact@data.gouv.fr
     - label: "Autre"
       id: autre
     - label: "Faire un retour sur la plateforme"
@@ -167,12 +155,6 @@ choices:
         form:
           title: Contactez-nous (nous vous invitons à consulter la documentation au préalable)
           recipient: certification@data.gouv.fr
-    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
-      id: droit-acces
-      link:
-        form:
-          title: Contactez-nous
-          recipient: contact@data.gouv.fr
     - label: "Question sur des données géographiques"
       id: geo
       link:
@@ -243,12 +225,6 @@ choices:
         form:
           title: Contactez-nous (nous vous invitons à consulter la documentation au préalable)
           recipient: certification@data.gouv.fr
-    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
-      id: droit-acces
-      link:
-        form:
-          title: Contactez-nous
-          recipient: contact@data.gouv.fr
     - label: "Question sur des données géographiques"
       id: geo
       link:
@@ -290,12 +266,6 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
-    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
-      id: droit-acces
-      link:
-        form:
-          title: Contactez-nous
-          recipient: contact@data.gouv.fr
     - label: "Question sur des données géographiques"
       id: geo
       link:
@@ -337,12 +307,6 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
-    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
-      id: droit-acces
-      link:
-        form:
-          title: Contactez-nous
-          recipient: contact@data.gouv.fr
     - label: "Question sur des données géographiques"
       id: geo
       link:
@@ -384,12 +348,6 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
-    - label: "Je souhaite exercer mon droit d’accès, de rectification et d’opposition"
-      id: droit-acces
-      link:
-        form:
-          title: Contactez-nous
-          recipient: contact@data.gouv.fr
     - label: "Question sur des données géographiques"
       id: geo
       link:

--- a/config/question-tree.yaml
+++ b/config/question-tree.yaml
@@ -106,14 +106,6 @@ choices:
         form:
           title: Contactez-nous
           recipient: support@data.gouv.fr
-    - label: "J'ai une demande relative à l'ouverture des données publiques : données absentes ou difficiles à trouver"
-      id: ouverture-donnees-publiques
-      link:
-        form:
-          title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
-          recipient: ouverture@data.gouv.fr
-    - label: "Autre"
-      id: autre
     - label: "Faire un retour sur la plateforme"
       id: retour-plateforme
       link:


### PR DESCRIPTION
cf. https://github.com/etalab/support.data.gouv.fr/issues/42

À discuter :
- Si l'option doit figurer dans tous les arbres (particulier, journaliste, admin, colter, etc.)
- Si l'adresse mail est ok
- Si on veut changer le titre de la box vers un truc genre :

> En application de la loi n° 78-17 du 6 janvier 1978 relative à l’informatique, aux fichiers et aux libertés, l’utilisateur dispose d’un droit d’accès, de rectification et d’opposition auprès d’Etalab. Ce droit s’exerce par ce form ou par voie postale à Mission Etalab, 20 avenue de Ségur, 75334 PARIS Cedex 07.