### PR TITLE
Ajout d'informations spécifiques sur la COVID-19

### DIFF
--- a/config/answers/info_covid.md
+++ b/config/answers/info_covid.md
@@ -1,0 +1,10 @@
+Ce canal de support est dédié aux demandes relatives à la plateforme ouverte des données publiques data.gouv.fr.
+Le site data.gouv.fr ne permet pas aux particuliers de remplir des formalités administratives et notre support n'est pas en mesure de vous aider sur ces sujets.
+
+Pour toute information sur la COVID-19, la campagne de vaccination et le pass sanitaire, vous pouvez consulter le site [gouvernement.fr](https://www.gouvernement.fr/info-coronavirus)
+
+Pour trouver un rendez vous, vous pouvez consulter [sante.fr](https://www.sante.fr/cf/centres-vaccination-covid.html).
+
+Pour récupérer votre attestation certifiée de vaccination (pass sanitaire), vous pouvez consulter votre espace [ameli.fr](https://attestation-vaccin.ameli.fr/).
+
+<button href="https://www.gouvernement.fr/info-coronavirus/vaccins">Aller sur gouvernement.fr</button>

--- a/config/answers/info_covid.md
+++ b/config/answers/info_covid.md
@@ -7,4 +7,6 @@ Pour trouver un rendez vous, vous pouvez consulter [sante.fr](https://www.sante.
 
 Pour récupérer votre attestation certifiée de vaccination (pass sanitaire), vous pouvez consulter votre espace [ameli.fr](https://attestation-vaccin.ameli.fr/).
 
+Pour toute question médicale, nous vous invitons à prendre conseil auprès de votre médecin traitant.
+
 <button href="https://www.gouvernement.fr/info-coronavirus/vaccins">Aller sur gouvernement.fr</button>

--- a/config/question-tree.yaml
+++ b/config/question-tree.yaml
@@ -38,6 +38,10 @@ choices:
         form:
           title: Contactez-nous (cette demande d'information n'est pas assimilable à une saisie CADA)
           recipient: ouverture@data.gouv.fr
+    - label: "J'ai une question relative au pass sanitaire ou au vaccin contre la COVID-19"
+      id: info-covid
+      link:
+        path: answers/info_covid.md
     - label: "Autre"
       id: autre
       link:


### PR DESCRIPTION
Ajout du parcours `Particulier > J'ai une question relative au pass sanitaire ou au vaccin contre la COVID-19` avec des informations spécifiques et des liens utiles. À voir si c'est pertinent et utile pour réduire le nombre d'email qu'on reçoit sur ce sujet.