### PR TITLE
Add ci on pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:


### PR DESCRIPTION
CI isn't working on PR, ex: https://github.com/etalab/support.data.gouv.fr/pull/43

(see also discussion to prevent workflow to run twice for push and pr: https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662/7)